### PR TITLE
Fix text background color conflicts

### DIFF
--- a/presets/flat.json
+++ b/presets/flat.json
@@ -5,7 +5,7 @@
     "popup_colors":  "black,white",
     "dark_gray":  "#f9f7f3",
     "screen_colors":  "white,black",
-    "dark_green":  "#a5c261",
+    "dark_green":  "#909193",
     "window_size":  "80x25",
     "font_weight":  0,
     "screen_buffer_size":  "80x3000",


### PR DESCRIPTION
Both text and his backgound has the same color causing hidden texts in some cases, fixed.