### PR TITLE
Add Firefly theme.

### DIFF
--- a/presets/firefly.json
+++ b/presets/firefly.json
@@ -1,0 +1,30 @@
+{
+  "black": "#222211",
+  "white": "#ffffff",
+  "gray": "#c0c0c0",
+  "dark_gray": "#808080",
+
+  "dark_blue": "#0099ff",
+  "blue": "#0099ff",
+  "dark_green": "#66ff33",
+  "green": "#66ff33",
+  "dark_cyan": "#00ffcc",
+  "cyan": "#00ffcc",
+  "dark_red": "#ff3300",
+  "red": "#ff3300",
+  "dark_magenta": "#ff3399",
+  "magenta": "#ff3399",
+  "dark_yellow": "#ffff00",
+  "yellow": "#ffff00",
+  
+  "screen_colors": "white,black",
+  "font_face": "Consolas",
+  "font_true_type": true,
+  "font_size": "0x18",
+  "font_weight": 0,
+  "window_size": "128x32",
+  "cursor_size": "small",
+  "quick_edit": false,
+  "insert_mode": true,
+  "load_console_IME": true
+}


### PR DESCRIPTION
The design goals of this theme are:
- Create a theme that is legible and easy on the eyes.
- Create a theme that is compatible with [chalk](https://github.com/chalk/chalk) module for NodeJS on PowerShell.

Here are the step-by-step behind the creation of the theme:
1. Start with cmd.exe defaults due to excellent compatibility with chalk.
2. Change the default text color to white for improved legibility.
3. Tone down the background to off-black with [reduced blue](https://9to5mac.com/2017/03/28/flux-developer-says-apples-new-competitive-macos-night-shift-feature-falls-short/) to [reduce contrast](https://ianstormtaylor.com/design-tip-never-use-black/).
4. Set all colors (except grey) to the brighter variant. (e.g. `dark_red` to `red`)
5. Add tone to the colors to improve their characters. (e.g. slight yellow to red, slight green to blue / cyan, slight red to magenta, slight yellow to green)
6. Set font to Consolas, font-size to 18, and acceptable default window size.

## Preview

![firefly](https://user-images.githubusercontent.com/8892187/27001081-60e48c84-4deb-11e7-837b-884de2080e70.PNG)

Compared to cmd.exe defaults and PowerShell defaults:

![defaults](https://user-images.githubusercontent.com/8892187/27001082-6af948c2-4deb-11e7-86e3-0f7e19e7e1c1.PNG)

![powershell-defaults](https://user-images.githubusercontent.com/8892187/27001083-6e070ba8-4deb-11e7-9798-df1d5ef30abb.PNG)

> Notice that chalk magenta color disappears on PowerShell defaults!