### PR TITLE
Check for PSCore pwsh.exe

### DIFF
--- a/libexec/clean.ps1
+++ b/libexec/clean.ps1
@@ -8,6 +8,7 @@
 
 . "$psscriptroot\..\lib\shortcut.ps1"
 $pspath = "$pshome\powershell.exe"
+$pscorepath = "$pshome\pwsh.exe"
 
 function cleandir($dir) {
 	if(!(test-path $dir)) { return }
@@ -16,7 +17,7 @@ function cleandir($dir) {
 		if($_.psiscontainer) { cleandir $_.fullname }
 		else {
 			$path = $_.fullname
-			if(linksto $path $pspath) {
+			if((linksto $path $pspath) -or (linksto $path $pscorepath)) {
 				if(!(rmprops $path)) {
 					write-host "warning: admin permission is required to remove console props from $path" -f darkyellow
 				}

--- a/libexec/import.ps1
+++ b/libexec/import.ps1
@@ -140,7 +140,11 @@ if(!$non_interactive) {
 	}
 
 	$yn = read-host "would you like to open a new console to see the changes? (Y/n)"
-	if(!$yn -or ($yn -like 'y*')) { start 'powershell.exe' -arg -nologo }
+	$ps_exe = 'powershell.exe'
+	if (Test-Path "$pshome\pwsh.exe") {
+		$ps_exe = "$pshome\pwsh.exe"
+	}
+	if(!$yn -or ($yn -like 'y*')) { start $ps_exe -arg -nologo }
 } else {
 	write-host (wraptext "please start a new console to see changes")
 	write-host (wraptext "you may also need to run 'concfg clean' to remove overrides from the registry and shortcut files.")


### PR DESCRIPTION
This patch enables cleaning PSCore (PS6) shortcuts and using it as the preview console when running it (`pwsh.exe`) rather than Windows PowerShell (`powershell.exe`).