### PR TITLE
Update README with the right `defaults` import

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ concfg import solarized-dark
 
 Revert to the stock-standard console settings:
 ```
-concfg import defaults
+concfg import windows-console-defaults
 ```
 
 ##### Importing settings from a URL


### PR DESCRIPTION
The current README has instructions for console window defaults which don't work.