### PR TITLE
fix: compatible with powershell core 6.1.x

### DIFF
--- a/libexec/help.ps1
+++ b/libexec/help.ps1
@@ -22,7 +22,7 @@ function print_summaries {
 
 	command_files | ForEach-Object {
 		$command = command_name $_
-		$summary = summary (Get-Content ("$psscriptroot\$_") -raw )
+		$summary = summary (Get-Content $_.FullName -raw )
 		if(!($summary)) { $summary = '' }
 		$commands.add("$command ", $summary) # add padding
 	}

--- a/libexec/tokencolor.ps1
+++ b/libexec/tokencolor.ps1
@@ -100,18 +100,19 @@ function settokencolor ($non_interactive) {
             $options.TypeForegroundColor      = "DarkYellow"  # base0A
             $options.VariableForegroundColor  = "DarkRed"     # base08
         } else {
-            $options = Get-PSReadlineOption
             # Token Foreground                                # base16 colors
-            $options.CommandColor   = "$([char]0x1b)[34m"     # base0D
-            $options.CommentColor   = "$([char]0x1b)[93m"     # base03
-            $options.KeywordColor   = "$([char]0x1b)[35m"     # base0E
-            $options.MemberColor    = "$([char]0x1b)[34m"     # base0D
-            $options.NumberColor    = "$([char]0x1b)[91m"     # base09
-            $options.OperatorColor  = "$([char]0x1b)[36m"     # base0C
-            $options.ParameterColor = "$([char]0x1b)[91m"     # base09
-            $options.StringColor    = "$([char]0x1b)[32m"     # base0B
-            $options.TypeColor      = "$([char]0x1b)[33m"     # base0A
-            $options.VariableColor  = "$([char]0x1b)[31m"     # base08
+            Set-PSReadLineOption -Colors @{
+                "Command"   = [ConsoleColor]::DarkBlue        # base0D
+                "Comment"   = [ConsoleColor]::Yellow          # base03
+                "Keyword"   = [ConsoleColor]::DarkMagenta     # base0E
+                "Member"    = [ConsoleColor]::DarkBlue        # base0D
+                "Number"    = [ConsoleColor]::Red             # base09
+                "Operator"  = [ConsoleColor]::DarkCyan        # base0C
+                "Parameter" = [ConsoleColor]::Red             # base09
+                "String"    = [ConsoleColor]::DarkGreen       # base0B
+                "Type"      = [ConsoleColor]::DarkYellow      # base0A
+                "Variable"  = [ConsoleColor]::DarkRed         # base08
+            }
         }
 
         if (!$non_interactive) {
@@ -132,18 +133,19 @@ function resettokencolor ($non_interactive) {
             # Reset
             Set-PSReadlineOption -ResetTokenColors
         } else {
-            $options = Get-PSReadlineOption
-            # Default Colors                       
-            $options.CommandColor   = "$([char]0x1b)[93m"
-            $options.CommentColor   = "$([char]0x1b)[32m"
-            $options.KeywordColor   = "$([char]0x1b)[92m"
-            $options.MemberColor    = "$([char]0x1b)[97m"
-            $options.NumberColor    = "$([char]0x1b)[97m"
-            $options.OperatorColor  = "$([char]0x1b)[90m"
-            $options.ParameterColor = "$([char]0x1b)[90m"
-            $options.StringColor    = "$([char]0x1b)[36m"
-            $options.TypeColor      = "$([char]0x1b)[37m"
-            $options.VariableColor  = "$([char]0x1b)[92m"
+            # Default Colors
+            Set-PSReadLineOption -Colors @{
+                "Command"   = [ConsoleColor]::Yellow
+                "Comment"   = [ConsoleColor]::DarkGreen
+                "Keyword"   = [ConsoleColor]::Green
+                "Member"    = [ConsoleColor]::White
+                "Number"    = [ConsoleColor]::White
+                "Operator"  = [ConsoleColor]::DarkGray
+                "Parameter" = [ConsoleColor]::DarkGray
+                "String"    = [ConsoleColor]::DarkCyan
+                "Type"      = [ConsoleColor]::Gray
+                "Variable"  = [ConsoleColor]::Green
+            }
         }
 
         if (!$non_interactive) {


### PR DESCRIPTION
1. `concfg [help]` command now is compatible with powershell core 6.1.x
2. use `Set-PSReadLineOption -Colors @{}` to change token colors. cf. [PSReadLine doc](https://github.com/lzybkr/PSReadLine/blob/master/docs/Set-PSReadLineOption.md#examples)
