### PR TITLE
Fix display of directories in ls command

### DIFF
--- a/presets/back-to-the-code.json
+++ b/presets/back-to-the-code.json
@@ -1,7 +1,7 @@
 {
     "black":        "#1c1d21",
     "dark_blue":    "#4FB4D8",
-    "dark_green":   "#78BD65",
+    "dark_green":   "#1d6608",
     "dark_cyan":    "#00DCDC",
     "dark_red":     "#EB3D54",
     "dark_magenta": "#9b37e2",
@@ -19,22 +19,22 @@
     "screen_colors": "gray,black",
     "popup_colors":  "dark_magenta,white",
 
-	"font_face":      "Consolas",
-	"font_true_type": true,
-	"font_size":      "0x16",
-	"font_weight":    400,
+    "font_face":      "Consolas",
+    "font_true_type": true,
+    "font_size":      "0x16",
+    "font_weight":    400,
 
-	"cursor_size": "small", 
+    "cursor_size": "small", 
 
-	"window_size":        "100x32",
-	"screen_buffer_size": "80x200",
+    "window_size":        "100x32",
+    "screen_buffer_size": "80x200",
 
-	"command_history_length": 50,
-	"num_history_buffers":     4,
+    "command_history_length": 50,
+    "num_history_buffers":     4,
 
-	"quick_edit":  true,
-	"insert_mode": true,
-	"fullscreen":  false,
+    "quick_edit":  true,
+    "insert_mode": true,
+    "fullscreen":  false,
 
-	"load_console_IME":  true
+    "load_console_IME":  true
 }


### PR DESCRIPTION
When using the ls command in WSL, the display of directories was illegible.
The dark green has been darkened to add contrast.

### Before

![image](https://user-images.githubusercontent.com/10633170/50908827-8bd01d80-13f8-11e9-85ec-2517099fbc44.png)


### After
![image](https://user-images.githubusercontent.com/10633170/50908910-ab674600-13f8-11e9-9378-a7d6c2f262c8.png)